### PR TITLE
feature: Add support for bucket lifecycle

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,8 @@
         {ibrowse, ".*",
          %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
          {git, "git@github.com:cmullaparthi/ibrowse.git", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
-        {envy, {git, "https://github.com/markan/envy.git", {branch, "master"}}}
+        {envy, {git, "https://github.com/markan/envy.git", {branch, "master"}}},
+        {recon, {git, "git@github.com:kivra/recon.git", {tag, "2.5.2"}}}
        ]}.
 
 {profiles, [{ test, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,4 +5,8 @@
  {<<"ibrowse">>,
   {git,"git@github.com:cmullaparthi/ibrowse.git",
        {ref,"c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}},
+  0},
+ {<<"recon">>,
+  {git,"git@github.com:kivra/recon.git",
+       {ref,"34194da6d9f8ed25f274e0ebb098dc9e95bcf547"}},
   0}].


### PR DESCRIPTION
## Description

Adds support to `get`, `put` and `delete` operations for bucket lifecycle functionality 

__NOTE__: It doesn't currently support all the options, just the ones needed for the current use case: Expiration TTL in days for current and non current versions.